### PR TITLE
Fix installation at root

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -46,7 +46,7 @@ DEBUG = False
 LOG_LEVEL = "WARNING"
 ADMIN_EMAIL = "__EMAIL__"
 DEFAULT_FROM_EMAIL = "__EMAIL__"
-FORCE_SCRIPT_NAME = f"/{PATH_URL}"
+FORCE_SCRIPT_NAME = f"/{PATH_URL}" if PATH_URL else None
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

 - The installation at the root of a domain does not work

## Solution

`FORCE_SCRIPT_NAME` should be set to `None` when installing at the root.

